### PR TITLE
fix: configure git identity in cleanup workflow

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -26,6 +26,8 @@ jobs:
           ref: generated-docs-preview
       - name: Clean docs branch
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           cd pr/
           # keep the last 25 prs
           dirs=$(ls -1d [0-9]* | sort -n)
@@ -35,5 +37,6 @@ jobs:
             echo "$dirs_to_remove" | xargs rm -rf
           fi
           git add .
+          git diff --cached --quiet && echo "Nothing to clean up" && exit 0
           git commit -m "Cleanup old docs"
           git push


### PR DESCRIPTION
## Summary
- The `clean_docs_branch` job fails with `fatal: empty ident name` because no git `user.name`/`user.email` is configured on the runner
- Also adds a guard for the "nothing to commit" case (when ≤25 PR dirs exist)

Same fix as https://github.com/n0-computer/iroh/pull/3920